### PR TITLE
Homebrew now supports shallow taps for CI!

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,6 @@ jobs:
     strategy: { matrix: { os: [ubuntu, macOS] } }
     steps:
     - uses: actions/checkout@v2
+    - run: npm install
     - uses: ./
     - run: brew --version

--- a/src/installer.js
+++ b/src/installer.js
@@ -16,7 +16,9 @@ module.exports = {
   },
 
   installTaps: async function (taps) {
-    return Promise.all(normalizeTapNames(taps).map(t => exec(`brew tap ${t}`)))
+    return Promise.all(
+      normalizeTapNames(taps).map(t => exec(`brew tap --shallow ${t}`))
+    )
   }
 }
 


### PR DESCRIPTION
This now explicitly clones tap "shallow".

https://github.com/Homebrew/brew/pull/7311

closes #2 