### PR TITLE
Use native homebrew

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.1.1",
+    "@actions/exec": "^1.0.3",
     "@actions/tool-cache": "^1.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@actions/core": "^1.1.1",
-    "@actions/exec": "^1.0.3",
     "@actions/tool-cache": "^1.3.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,6 @@ module.exports.catch(err => core.setFailed(err.message))
 
 function run () {
   return installHomebrew(core.getInput('brew-version'))
-    .then(() => exec('brew help')) // ensures bottled ruby is available
     .then(() => installTaps(core.getInput('taps')))
+    .then(() => exec('brew tap')) // show installed taps
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-const { execSync } = require('child_process')
 const core = require('@actions/core')
+const { exec } = require('@actions/exec')
 const { installHomebrew, installTaps } = require('./installer')
 
 module.exports = run()
@@ -8,5 +8,5 @@ module.exports.catch(err => core.setFailed(err.message))
 function run () {
   return installHomebrew(core.getInput('brew-version'))
     .then(() => installTaps(core.getInput('taps')))
-    .then(() => execSync('brew tap')) // show installed taps
+    .then(() => exec('brew tap')) // show installed taps
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
+const { execSync } = require('child_process')
 const core = require('@actions/core')
-const { exec } = require('@actions/exec')
 const { installHomebrew, installTaps } = require('./installer')
 
 module.exports = run()
@@ -8,5 +8,5 @@ module.exports.catch(err => core.setFailed(err.message))
 function run () {
   return installHomebrew(core.getInput('brew-version'))
     .then(() => installTaps(core.getInput('taps')))
-    .then(() => exec('brew tap')) // show installed taps
+    .then(() => execSync('brew tap')) // show installed taps
 }

--- a/src/installer.js
+++ b/src/installer.js
@@ -1,6 +1,6 @@
+const { execSync } = require('child_process')
 const path = require('path')
 const core = require('@actions/core')
-const { exec } = require('@actions/exec')
 const tools = require('@actions/tool-cache')
 
 const TOOL_NAME = 'homebrew'
@@ -17,14 +17,16 @@ module.exports = {
 
   installTaps: async function (taps) {
     return Promise.all(
-      normalizeTapNames(taps).map(t => exec(`brew tap --shallow ${t}`))
+      normalizeTapNames(taps).map(t => execSync(`brew tap --shallow ${t}`))
     )
   }
 }
 
 async function gitClone () {
   const prefix = `${process.env.HOME}/Homebrew`
-  await exec(`git clone --depth=1 https://github.com/Homebrew/brew ${prefix}`)
+  await execSync(
+    `git clone --depth=1 https://github.com/Homebrew/brew ${prefix}`
+  )
   return prefix
 }
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -43,5 +43,8 @@ async function downloadHomebrew (version) {
 }
 
 function normalizeTapNames (taps) {
-  return (taps || '').split(',').map(t => (t.match('/') ? t : `homebrew/${t}`))
+  return (taps || '')
+    .split(',')
+    .map(t => t.trim())
+    .map(t => (t.match('/') ? t : `homebrew/${t}`))
 }

--- a/src/installer.js
+++ b/src/installer.js
@@ -7,6 +7,10 @@ const TOOL_NAME = 'homebrew'
 
 module.exports = {
   installHomebrew: async function (version) {
+    // If homebrew is already available and a specific version isn't requested
+    // just quit early.
+    if (version === 'master' && homebrewAvailable()) return
+
     const toolPath = version === 'master' ? gitClone() : toolCache(version)
 
     // prepend bin directory to PATH for future tasks
@@ -19,6 +23,15 @@ module.exports = {
     return Promise.all(
       normalizeTapNames(taps).map(t => execSync(`brew tap --shallow ${t}`))
     )
+  }
+}
+
+function homebrewAvailable () {
+  try {
+    execSync('command -v brew')
+    return true
+  } catch {
+    return false
   }
 }
 


### PR DESCRIPTION
It would be nice to leverage the out-of-the-box homebrew when it's available on macOS. That will make this action super fast on macOS.

- initially switched from @actions/exec to node's execSync. Downside is that commands are no longer echoed to the runner :( need to revert this
- using the 'brew-version' as an indication if the user allows native homebrew is not great. Firstly, there is no indication between a user omitting the brew-version input, vs explicitly requesting `master`.  Secondly, some users may be fine with whatever stale homebrew configuration exists, whereas others (homebrew themselves, taps, etc) my require LATEST. Need to investigate this more.